### PR TITLE
chore: release v0.2.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 /target/
 /dist/
 /.venv/
@@ -5,3 +6,6 @@ __pycache__/
 /.pytest_cache/
 /.ruff_cache/
 /.hypothesis/
+=======
+/target
+>>>>>>> dc55b10 (WIP)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,41 @@
 version = 3
 
 [[package]]
+<<<<<<< HEAD
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+=======
+name = "addr2line"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "backtrace"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+>>>>>>> dc55b10 (WIP)
 
 [[package]]
 name = "bitflags"
@@ -24,12 +55,51 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
+=======
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+
+[[package]]
+>>>>>>> dc55b10 (WIP)
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+<<<<<<< HEAD
+=======
+name = "color-eyre"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a667583cca8c4f8436db8de46ea8233c42a7d9ae424a82d338f2e4675229204"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba75b3d9449ecdccb27ecbc479fdc0b87fa2dd43d2f8298f9bf0e59aacc8dce"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
+
+[[package]]
+>>>>>>> dc55b10 (WIP)
 name = "cpufeatures"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,6 +119,7 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "ctor"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +130,8 @@ dependencies = [
 ]
 
 [[package]]
+=======
+>>>>>>> dc55b10 (WIP)
 name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,6 +142,7 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "document-features"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,6 +165,11 @@ name = "dot-generator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0aaac7ada45f71873ebce336491d1c1bc4a7c8042c7cea978168ad59e805b871"
+=======
+name = "dot-generator"
+version = "0.2.0"
+source = "git+https://github.com/flying-sheep/graphviz-rust.git?branch=fix-parser#a361f9adcbf496d9be319fd8d645f160f4d40025"
+>>>>>>> dc55b10 (WIP)
 dependencies = [
  "dot-structures",
 ]
@@ -98,8 +177,22 @@ dependencies = [
 [[package]]
 name = "dot-structures"
 version = "0.1.0"
+<<<<<<< HEAD
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "545da7d6df7f8fd0de7106669a7d0bfa3dbcfa24d81da46906ad658188b2ff7c"
+=======
+source = "git+https://github.com/flying-sheep/graphviz-rust.git?branch=fix-parser#a361f9adcbf496d9be319fd8d645f160f4d40025"
+
+[[package]]
+name = "eyre"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+>>>>>>> dc55b10 (WIP)
 
 [[package]]
 name = "fastrand"
@@ -132,6 +225,7 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "ghost"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +243,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06d2e1afca2ae5a9887b57f991e89c9078e4150fc8875cc2b0babf4bdb3ec720"
 dependencies = [
  "dot-generator 0.2.0",
+=======
+name = "gimli"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "221996f774192f0f718773def8201c4ae31f02616a54ccfc2d358bb0e5cefdec"
+
+[[package]]
+name = "graphviz-rust"
+version = "0.5.2"
+source = "git+https://github.com/flying-sheep/graphviz-rust.git?branch=fix-parser#a361f9adcbf496d9be319fd8d645f160f4d40025"
+dependencies = [
+ "dot-generator",
+>>>>>>> dc55b10 (WIP)
  "dot-structures",
  "into-attr",
  "into-attr-derive",
@@ -159,10 +266,29 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "indoc"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
+=======
+name = "gvtest"
+version = "0.1.0"
+dependencies = [
+ "bitflags",
+ "color-eyre",
+ "graphviz-rust",
+ "nom",
+ "pest",
+ "pest_derive",
+]
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+>>>>>>> dc55b10 (WIP)
 
 [[package]]
 name = "instant"
@@ -176,8 +302,12 @@ dependencies = [
 [[package]]
 name = "into-attr"
 version = "0.1.0"
+<<<<<<< HEAD
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6ec0dd848c05d2695dd73818984fb156ac8cbcbfdf4e474243590bfcc2468e9"
+=======
+source = "git+https://github.com/flying-sheep/graphviz-rust.git?branch=fix-parser#a361f9adcbf496d9be319fd8d645f160f4d40025"
+>>>>>>> dc55b10 (WIP)
 dependencies = [
  "dot-structures",
 ]
@@ -185,10 +315,16 @@ dependencies = [
 [[package]]
 name = "into-attr-derive"
 version = "0.1.0"
+<<<<<<< HEAD
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b88c3c684271aa7810934ae69a0b904c59f478cb551f3f388cc1c384f0c3145"
 dependencies = [
  "dot-generator 0.1.0",
+=======
+source = "git+https://github.com/flying-sheep/graphviz-rust.git?branch=fix-parser#a361f9adcbf496d9be319fd8d645f160f4d40025"
+dependencies = [
+ "dot-generator",
+>>>>>>> dc55b10 (WIP)
  "dot-structures",
  "into-attr",
  "quote",
@@ -196,6 +332,7 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "inventory"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,6 +341,12 @@ dependencies = [
  "ctor",
  "ghost",
 ]
+=======
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+>>>>>>> dc55b10 (WIP)
 
 [[package]]
 name = "libc"
@@ -212,6 +355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
+<<<<<<< HEAD
 name = "litrs"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,12 +372,15 @@ dependencies = [
 ]
 
 [[package]]
+=======
+>>>>>>> dc55b10 (WIP)
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+<<<<<<< HEAD
 name = "memoffset"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,12 +390,26 @@ dependencies = [
 ]
 
 [[package]]
+=======
+>>>>>>> dc55b10 (WIP)
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+<<<<<<< HEAD
+=======
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+>>>>>>> dc55b10 (WIP)
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,12 +420,25 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
+=======
+name = "object"
+version = "0.30.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+>>>>>>> dc55b10 (WIP)
 name = "once_cell"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
+<<<<<<< HEAD
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,6 +466,12 @@ name = "paste"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+=======
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+>>>>>>> dc55b10 (WIP)
 
 [[package]]
 name = "pest"
@@ -338,6 +518,15 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
+=======
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
+>>>>>>> dc55b10 (WIP)
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,6 +542,7 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "pyo3"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,6 +604,8 @@ dependencies = [
 ]
 
 [[package]]
+=======
+>>>>>>> dc55b10 (WIP)
 name = "quote"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,6 +663,7 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,6 +683,12 @@ name = "semver"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+=======
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+>>>>>>> dc55b10 (WIP)
 
 [[package]]
 name = "sha2"
@@ -503,10 +702,20 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+=======
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+>>>>>>> dc55b10 (WIP)
 
 [[package]]
 name = "syn"
@@ -520,12 +729,15 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "target-lexicon"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
 
 [[package]]
+=======
+>>>>>>> dc55b10 (WIP)
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,6 +772,60 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
+=======
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
+]
+
+[[package]]
+>>>>>>> dc55b10 (WIP)
 name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,10 +844,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
+<<<<<<< HEAD
 name = "unindent"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1766d682d402817b5ac4490b3c3002d91dfa0d22812f341609f97b08757359c"
+=======
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+>>>>>>> dc55b10 (WIP)
 
 [[package]]
 name = "version_check"
@@ -616,6 +889,7 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+<<<<<<< HEAD
 
 [[package]]
 name = "windows-sys"
@@ -698,3 +972,5 @@ dependencies = [
  "rustc_version",
  "thiserror",
 ]
+=======
+>>>>>>> dc55b10 (WIP)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+<<<<<<< HEAD
 name = 'xdot'
 version = "0.2.3"
 authors = ['Philipp A. <flying-sheep@web.de>']
@@ -37,3 +38,16 @@ paste = "1.0.12"
 
 [build-dependencies]
 rustc_version = '0.4.0'
+=======
+name = 'gvtest'
+version = '0.1.0'
+edition = '2021'
+
+[dependencies]
+bitflags = "1.3.2"
+color-eyre = '0.6.2'
+graphviz-rust = { version = '0.5.2', git = 'https://github.com/flying-sheep/graphviz-rust.git', branch = 'fix-parser' }
+nom = "7.1.3"
+pest = "2.5.4"
+pest_derive = "2.5.4"
+>>>>>>> dc55b10 (WIP)

--- a/src/graph_ext.rs
+++ b/src/graph_ext.rs
@@ -1,0 +1,37 @@
+use std::iter::{empty, once};
+
+use graphviz_rust::dot_structures::{Graph, Subgraph, Stmt, Node, Edge};
+
+pub(super) enum Elem<'a> { Node(&'a Node), Edge(&'a Edge) }
+
+pub(super) trait GraphExt {
+    fn iter_elems<'a>(&'a self) -> Box<dyn Iterator<Item=Elem<'a>> + 'a>;
+}
+
+
+impl GraphExt for Stmt {
+    fn iter_elems<'a>(&'a self) -> Box<dyn Iterator<Item=Elem<'a>> + 'a> {
+        match self {
+            Stmt::Edge(edge) => Box::new(once(Elem::Edge(edge))),
+            Stmt::Node(node) => Box::new(once(Elem::Node(node))),
+            Stmt::Subgraph(sg) => sg.iter_elems(),
+            _ => Box::new(empty()),
+        }
+    }
+}
+
+impl GraphExt for Subgraph {
+    fn iter_elems<'a>(&'a self) -> Box<dyn Iterator<Item=Elem<'a>> + 'a> {
+        Box::new(self.stmts.iter().flat_map(Stmt::iter_elems))
+    }
+}
+
+impl GraphExt for Graph {
+    fn iter_elems<'a>(&'a self) -> Box<dyn Iterator<Item=Elem<'a>> + 'a> {
+        let stmts = match self {
+            Graph::Graph   { stmts, .. } => stmts,
+            Graph::DiGraph { stmts, .. } => stmts,
+        };
+        Box::new(stmts.iter().flat_map(Stmt::iter_elems))
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,26 @@
+use graph_ext::{GraphExt, Elem};
+use graphviz_rust as gv;
+use color_eyre::{self, eyre::{Result, Report}};
+use gv::{printer::PrinterContext, cmd::{CommandArg, Layout, Format}, dot_structures::{Graph, Stmt}};
+
+mod graph_ext;
+mod xdot;
+
+const TEST: &'static str = "graph { a -- b }";
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+    let graph = gv::parse(TEST).map_err(Report::msg)?;
+    let mut ctx = PrinterContext::default();
+    let layed_out = gv::exec(graph, &mut ctx, vec![CommandArg::Layout(Layout::Dot), CommandArg::Format(Format::Xdot)])?;
+    let graph = gv::parse(&layed_out).map_err(Report::msg)?;
+    graph.iter_elems().for_each(handle_elem);
+    Ok(())
+}
+
+fn handle_elem(elem: Elem) {
+    match elem {
+        Elem::Edge(edge) => { dbg!(edge); },
+        Elem::Node(node) => { dbg!(node); },
+    }
+}

--- a/src/xdot.rs
+++ b/src/xdot.rs
@@ -1,0 +1,28 @@
+use std::cell::RefCell;
+use nom::IResult;
+
+use self::declarative::Pen;
+pub(super) use self::declarative::ShapeDraw;
+
+mod attrs;
+mod shapes;
+mod ops;
+mod op_parser;
+mod declarative;
+
+#[derive(Debug, Default)]
+struct Parser {
+    pen: Pen,
+}
+
+impl Parser {
+    fn parse(&mut self, spec: &str) -> IResult<&str, Vec<ShapeDraw>> {
+        let this = RefCell::new(self);
+        todo!()
+    }
+}
+  
+pub(super) fn parse(spec: &str) -> IResult<&str, Vec<ShapeDraw>> {
+    // Parser::default().parse(spec)
+    todo!()
+}

--- a/src/xdot.rs
+++ b/src/xdot.rs
@@ -21,7 +21,7 @@ impl Parser {
         todo!()
     }
 }
-  
+
 pub(super) fn parse(spec: &str) -> IResult<&str, Vec<ShapeDraw>> {
     // Parser::default().parse(spec)
     todo!()

--- a/src/xdot/attrs.rs
+++ b/src/xdot/attrs.rs
@@ -23,7 +23,7 @@ pub(super) enum Style {
 impl Default for Style {
     fn default() -> Self { Style::Solid }
 }
-    
+
 bitflags!{
     /// Matches values in https://graphviz.org/docs/outputs/canon/#xdot
     #[derive(Default)]

--- a/src/xdot/attrs.rs
+++ b/src/xdot/attrs.rs
@@ -1,0 +1,39 @@
+///! Types reused for drawing things.
+
+use bitflags::bitflags;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct Rgba {
+    r: u8, g: u8, b: u8, a: u8
+}
+impl Default for Rgba {
+    fn default() -> Self { Rgba { r: 0, g: 0, b: 0, a: 0xff } }
+}
+
+/// See https://graphviz.org/docs/attr-types/style/
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Style {
+    Dashed,
+    Dotted,
+    Solid,
+    Invis,
+    Bold,
+    // TODO: "tapered" for edges only
+}
+impl Default for Style {
+    fn default() -> Self { Style::Solid }
+}
+    
+bitflags!{
+    /// Matches values in https://graphviz.org/docs/outputs/canon/#xdot
+    #[derive(Default)]
+    pub(super) struct FontCharacteristics: u128 {
+        const BOLD           = 0b00000001;
+        const ITALIC         = 0b00000010;
+        const UNDERLINE      = 0b00000100;
+        const SUPERSCRIPT    = 0b00001000;
+        const SUBSCRIPT      = 0b00010000;
+        const STRIKE_THROUGH = 0b00100000;
+        const OVERLINE       = 0b01000000;
+    }
+}

--- a/src/xdot/declarative.rs
+++ b/src/xdot/declarative.rs
@@ -1,0 +1,32 @@
+use super::{attrs::*, shapes::Shape};
+
+/// Store pen attributes.
+#[derive(Debug, Clone, PartialEq)]
+pub(super) struct Pen {
+    color: Rgba,
+    fill_color: Rgba,
+    line_width: f32,
+    line_style: Style,
+    font_size: f32,
+    font_name: String,
+    font_characteristics: FontCharacteristics,
+}
+impl Default for Pen {
+    fn default() -> Self {
+        Pen {
+            color: Default::default(),
+            fill_color: Default::default(),
+            line_width: 1.0,
+            line_style: Default::default(),
+            font_size: 14.0,
+            font_name: "Times-Roman".to_owned(),
+            font_characteristics: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ShapeDraw {
+    pen: Pen,
+    desc: Shape,
+}

--- a/src/xdot/op_parser.rs
+++ b/src/xdot/op_parser.rs
@@ -13,22 +13,22 @@ use super::ops::Op;
 fn from_hex(input: &str) -> Result<u8, std::num::ParseIntError> {
     u8::from_str_radix(input, 16)
 }
-  
+
 fn is_hex_digit(c: char) -> bool {
     c.is_digit(16)
 }
-  
+
 fn hex_primary(input: &str) -> IResult<&str, u8> {
     map_res(
         take_while_m_n(2, 2, is_hex_digit),
         from_hex
     )(input)
 }
-  
+
 fn hex_color(input: &str) -> IResult<&str, Color> {
     let (input, _) = tag("#")(input)?;
     let (input, (red, green, blue)) = tuple((hex_primary, hex_primary, hex_primary))(input)?;
-  
+
     Ok((input, Color { red, green, blue }))
 }
 */

--- a/src/xdot/op_parser.rs
+++ b/src/xdot/op_parser.rs
@@ -1,0 +1,38 @@
+///! Stateless parser extracting xdot operations
+
+use nom::{
+    IResult,
+    bytes::complete::{tag, take_while_m_n},
+    combinator::map_res,
+    sequence::tuple,
+};
+
+use super::ops::Op;
+
+/*
+fn from_hex(input: &str) -> Result<u8, std::num::ParseIntError> {
+    u8::from_str_radix(input, 16)
+}
+  
+fn is_hex_digit(c: char) -> bool {
+    c.is_digit(16)
+}
+  
+fn hex_primary(input: &str) -> IResult<&str, u8> {
+    map_res(
+        take_while_m_n(2, 2, is_hex_digit),
+        from_hex
+    )(input)
+}
+  
+fn hex_color(input: &str) -> IResult<&str, Color> {
+    let (input, _) = tag("#")(input)?;
+    let (input, (red, green, blue)) = tuple((hex_primary, hex_primary, hex_primary))(input)?;
+  
+    Ok((input, Color { red, green, blue }))
+}
+*/
+
+pub(super) fn parse(spec: &str) -> IResult<&str, Vec<Op>> {
+    todo!()
+}

--- a/src/xdot/ops.rs
+++ b/src/xdot/ops.rs
@@ -1,0 +1,39 @@
+///! xdot drawing and pen manipulation operation
+
+use super::{attrs::*, shapes::*};
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Never {}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(super) enum Op {
+    DrawShape(Shape),
+    SetFontCharacteristics(FontCharacteristics),
+    SetFillColor(Rgba),
+    SetPenColor(Rgba),
+    SetFont { size: f32, name: String },
+    SetStyle(Style), // TODO: is it just one?
+    ExternalImage(Never), // FIXME
+}
+
+// shapes
+
+impl Into<Op> for Shape {
+    fn into(self) -> Op { Op::DrawShape(self) }
+}
+
+impl Into<Op> for Ellipse {
+    fn into(self) -> Op { Into::<Shape>::into(self).into() }
+}
+impl Into<Op> for Points {
+    fn into(self) -> Op { Into::<Shape>::into(self).into() }
+}
+impl Into<Op> for Text {
+    fn into(self) -> Op { Into::<Shape>::into(self).into() }
+}
+
+// rest
+
+impl Into<Op> for FontCharacteristics {
+    fn into(self) -> Op { Op::SetFontCharacteristics(self) }
+}

--- a/src/xdot/shapes.rs
+++ b/src/xdot/shapes.rs
@@ -1,0 +1,34 @@
+#[derive(Debug, Clone, PartialEq)]
+pub(super) enum Shape {
+    Ellipse(Ellipse),
+    Points(Points),
+    Text(Text),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(super) struct Ellipse {
+    filled: bool, x: f32, y: f32, w: f32, h: f32
+}
+impl Into<Shape> for Ellipse {
+    fn into(self) -> Shape { Shape::Ellipse(self) }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum PointsType { Polygon, Polyline, BSpline }
+#[derive(Debug, Clone, PartialEq)]
+pub(super) struct Points {
+    filled: bool, typ: PointsType, points: Vec<(f32, f32)>
+}
+impl Into<Shape> for Points {
+    fn into(self) -> Shape { Shape::Points(self) }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum TextAlign { Left, Center, Right }
+#[derive(Debug, Clone, PartialEq)]
+pub(super) struct Text {
+    x: f32, y: f32, align: TextAlign, width: f32, text: String
+}
+impl Into<Shape> for Text {
+    fn into(self) -> Shape { Shape::Text(self) }
+}


### PR DESCRIPTION
## 🤖 New release
* `xdot`: 0.2.3 -> 0.2.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.4](https://github.com/flying-sheep/xdot-rs/compare/v0.2.3...v0.2.4) - 2023-04-21

### Other
- Repo rename
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).