### PR TITLE
chore: release v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4](https://github.com/flying-sheep/xdot-rs/compare/v0.2.3...v0.2.4) - 2024-01-16
+
+### Other
+- [pre-commit.ci] pre-commit autoupdate ([#94](https://github.com/flying-sheep/xdot-rs/pull/94))
+
 ## [0.2.3](https://github.com/flying-sheep/xdot-rs/compare/v0.2.2...v0.2.3) - 2023-04-20
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,7 +685,7 @@ checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "xdot"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "bitflags",
  "document-features",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'xdot'
-version = "0.2.3"
+version = "0.2.4"
 authors = ['Philipp A. <flying-sheep@web.de>']
 edition = '2021'
 description = 'Parse graphviz’ xdot draw instructions'


### PR DESCRIPTION
## 🤖 New release
* `xdot`: 0.2.3 -> 0.2.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.4](https://github.com/flying-sheep/xdot-rs/compare/v0.2.3...v0.2.4) - 2024-01-16

### Other
- [pre-commit.ci] pre-commit autoupdate ([#94](https://github.com/flying-sheep/xdot-rs/pull/94))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).