### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/flying-sheep/xdot-rs/compare/v0.2.3...v0.3.0) - 2026-04-07
+
+### Other
+
+- [pre-commit.ci] pre-commit autoupdate ([#233](https://github.com/flying-sheep/xdot-rs/pull/233))
+
 ## [0.2.3](https://github.com/flying-sheep/xdot-rs/compare/v0.2.2...v0.2.3) - 2023-04-20
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,7 +685,7 @@ checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "xdot"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "bitflags",
  "document-features",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'xdot'
-version = "0.2.3"
+version = "0.3.0"
 authors = ['Philipp A. <flying-sheep@web.de>']
 edition = '2021'
 description = 'Parse graphviz’ xdot draw instructions'


### PR DESCRIPTION



## 🤖 New release

* `xdot`: 0.2.3 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `xdot` breaking changes

```text
--- failure declarative_macro_missing: macro_rules declaration removed or renamed ---

Description:
A `macro_rules!` declarative macro cannot be invoked by its prior name. The macro may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/reference/macros-by-example.html#path-based-scope
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/declarative_macro_missing.ron

Failed in:
  macro impl_richcmp_eq, previously in file /tmp/.tmpUWfd0y/xdot/src/impl_help.rs:2

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant LayoutError:Decode in /tmp/.tmpaTu6LS/xdot-rs/src/layout.rs:23

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_parameter_count_changed.ron

Failed in:
  xdot::shapes::pymodule now takes 1 parameters instead of 2, in /tmp/.tmpaTu6LS/xdot-rs/src/xdot_parse/shapes.rs:133
  xdot::draw::pymodule now takes 1 parameters instead of 2, in /tmp/.tmpaTu6LS/xdot-rs/src/xdot_parse/draw.rs:72
  xdot::pymodule now takes 1 parameters instead of 2, in /tmp/.tmpaTu6LS/xdot-rs/src/lib.rs:37

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_missing.ron

Failed in:
  FontCharacteristics::from_bits_unchecked, previously in file /tmp/.tmpUWfd0y/xdot/src/xdot_parse/draw/attrs.rs:62
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/flying-sheep/xdot-rs/compare/v0.2.3...v0.3.0) - 2026-04-07

### Other

- [pre-commit.ci] pre-commit autoupdate ([#233](https://github.com/flying-sheep/xdot-rs/pull/233))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).