### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/flying-sheep/xdot-rs/compare/v0.2.4...v0.3.0) - 2026-05-27
+
+### Other
+
+- remove `extension-module` feature ([#251](https://github.com/flying-sheep/xdot-rs/pull/251))
+
 ## [0.2.4](https://github.com/flying-sheep/xdot-rs/compare/v0.2.3...v0.2.4) - 2026-05-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,7 +542,7 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "xdot"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "bitflags",
  "document-features",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'xdot'
-version = "0.2.4"
+version = "0.3.0"
 authors = ['Philipp A. <flying-sheep@web.de>']
 edition = '2024'
 description = 'Parse graphviz’ xdot draw instructions'


### PR DESCRIPTION



## 🤖 New release

* `xdot`: 0.2.4 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `xdot` breaking changes

```text
--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/feature_missing.ron

Failed in:
  feature extension-module in the package's Cargo.toml
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/flying-sheep/xdot-rs/compare/v0.2.4...v0.3.0) - 2026-05-27

### Other

- remove `extension-module` feature ([#251](https://github.com/flying-sheep/xdot-rs/pull/251))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).